### PR TITLE
renamed prospectus to remove spaces, fixes 404 error

### DIFF
--- a/dcbpw2016/index.html
+++ b/dcbpw2016/index.html
@@ -149,11 +149,10 @@
                 learn! It is a great way to give back to the community while
                 getting your name out.</p>
 
-                <p>Please read our <a href="/dcbpw2016/DC-Baltimore Perl
-                  Workshop 2016 - Sponsor Prospectus.pdf">DC-Baltimore Perl
-                  Workshop 2016 - Sponsor Prospectus</a>, and contact <a
-                                      href="mailto:sponsors@dcbpw.org">sponsors@dcbpw.org</a>
-                to get more information!</p>
+                <p>Please read our <a href="/dcbpw2016/DC-BaltimorePerlWorkshopProspectus2016.pdf">
+                  DC-Baltimore Perl Workshop 2016 - Sponsor Prospectus</a>, and contact <a
+                  href="mailto:sponsors@dcbpw.org">sponsors@dcbpw.org</a>
+                  to get more information!</p>
               </div>
             </div>
 


### PR DESCRIPTION
Updated Prospectus file name and index.html to reflect the new name of the prospectus. This commit is trying to fix the 404 error that comes up when you click on the prospectus link in its current state.