### PR TITLE
Overhaul "Venue" Page

### DIFF
--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -130,7 +130,7 @@ The Thumel Business Center of the University of Baltimore is very close to Penn 
   <li><a href='http://mta.maryland.gov/light-rail'>Light Rail</a>: The University of Baltimore/Mount Royal Station, with service from <a href='http://www.bwiairport.com/en'>BWI Airport</a>, is located adjacent to the <a href='http://www.fitzparking.com/'>Fitzgerald Garage</a>.
     <ul>
       <li><a href='https://goo.gl/maps/CxGWBPzm8YA2'>Google Maps</a> Directions
-      <li><a href='http://maps.apple.com/?saddr=&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps</a> Directions
+      <li><a href='http://maps.apple.com/?saddr=1200+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps</a> Directions
     </ul>
   <li>By Intercity Train: Baltimore's Penn Station is just around the corner from the Thumel Business Center.
     <ul>

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -146,7 +146,7 @@ The Thumel Business Center of the University of Baltimore is very close to Penn 
       <li><a href='http://www.nextbus.com/customStopSelector/fancyNewPredictionLayer.jsp?a=charm-city&r=purple&d=baltvc&s=pennsta_f&ts=charnort&cssFile=http://charmcitycirculator.com/sites/all/themes/ccc/nextbus-gmap.css#'>310 - Penn Station Northbound</a> (<a href='http://maps.apple.com/?saddr=1545+W+N.+Charles+St.%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201&dirflg=w'>Apple Maps</a> Directions, <a href='https://goo.gl/maps/4Nw2NqNYgXF2'>Google Maps</a> Directions)
       <li><a href='http://www.nextbus.com/customStopSelector/fancyNewPredictionLayer.jsp?a=charm-city&r=purple&d=baltvc&s=pennsta311_f&ts=pres_f&cssFile=http://charmcitycirculator.com/sites/all/themes/ccc/nextbus-gmap.css#'>321 - Penn Station Southbound</a> (<a href='http://maps.apple.com/?saddr=1600+W+St.+Paul+St.%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201&dirflg=w'>Apple Maps</a> Directions, <a href='https://goo.gl/maps/ihTfPAGLDy32'>Google Maps</a> Directions)
     </ul>
-  <li>By Intercity Train: Baltimore's Penn Station is just around the corner from the Thumel Business Center.
+  <li>Intercity Train: Baltimore's Penn Station is just around the corner from the Thumel Business Center.
     <ul>
       <li><a href='http://www.amtrak.com/servlet/ContentServer?pagename=am/am2Station/Station_Page&code=BAL'>Amtrak</a> has lines going through Baltimore from many US Cities.
       <li><a href='http://mta.maryland.gov/marc-train'>MARC</a> trains provide an affordable commuter route between DC and Baltimore.

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -126,7 +126,11 @@ The University of Baltimore is located at 1420 North Charles St. at Mount Royal 
       <li><a href='https://goo.gl/maps/pLFKJyT9YKm'>Google Maps</a> Directions
       <li><a href='http://maps.apple.com/?saddr=201+West+Preston+Street%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps</a> Directions
     </ul>
-  <li>Light Rail: The University of Baltimore/Mount Royal Station is located adjacent to the Fitzgerald Garage ( Mt Royal &amp; Oliver)
+  <li><a href='http://mta.maryland.gov/light-rail'>Light Rail</a>: The University of Baltimore/Mount Royal Station, with service from <a href='http://www.bwiairport.com/en'>BWI Airport</a>, is located adjacent to the <a href='http://www.fitzparking.com/'>Fitzgerald Garage</a>.
+    <ul>
+      <li><a href='https://goo.gl/maps/CxGWBPzm8YA2'>Google Maps</a> Directions
+      <li><a href='http://maps.apple.com/?saddr=&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps</a> Directions
+    </ul>
   <li>By Intercity Train: The University is one block south of Pennsylvania Station (Amtrak/MARC) on North Charles Street.
 </ul>
 

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -141,6 +141,11 @@ The Thumel Business Center of the University of Baltimore is very close to Penn 
       <li><a href='https://goo.gl/maps/CxGWBPzm8YA2'>Google Maps</a> Directions
       <li><a href='http://maps.apple.com/?saddr=1200+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps</a> Directions
     </ul>
+  <li><a href='http://www.charmcitycirculator.com/'>Charm City Circulator</a>: The <a href='http://www.charmcitycirculator.com/route/purple'>Purple Route</a> of Baltimore's free bus service has two stops within blocks of the University.
+    <ul>
+      <li><a href='http://www.nextbus.com/customStopSelector/fancyNewPredictionLayer.jsp?a=charm-city&r=purple&d=baltvc&s=pennsta_f&ts=charnort&cssFile=http://charmcitycirculator.com/sites/all/themes/ccc/nextbus-gmap.css#'>310 - Penn Station Northbound</a> (<a href='http://maps.apple.com/?saddr=1545+W+N.+Charles+St.%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201&dirflg=w'>Apple Maps</a> Directions, <a href='https://goo.gl/maps/4Nw2NqNYgXF2'>Google Maps</a> Directions)
+      <li><a href='http://www.nextbus.com/customStopSelector/fancyNewPredictionLayer.jsp?a=charm-city&r=purple&d=baltvc&s=pennsta311_f&ts=pres_f&cssFile=http://charmcitycirculator.com/sites/all/themes/ccc/nextbus-gmap.css#'>321 - Penn Station Southbound</a> (<a href='http://maps.apple.com/?saddr=1600+W+St.+Paul+St.%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201&dirflg=w'>Apple Maps</a> Directions, <a href='https://goo.gl/maps/ihTfPAGLDy32'>Google Maps</a> Directions)
+    </ul>
   <li>By Intercity Train: Baltimore's Penn Station is just around the corner from the Thumel Business Center.
     <ul>
       <li><a href='http://www.amtrak.com/servlet/ContentServer?pagename=am/am2Station/Station_Page&code=BAL'>Amtrak</a> has lines going through Baltimore from many US Cities.

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -108,7 +108,7 @@ $12 Daily Max</p>
 
 <h2>Access via Public Transportation:</h2>
 <ul>
-  <li>MTA Buses &mdash; there are many in the area, but these are the closest (within one block of the venue):
+  <li><a href='http://mta.maryland.gov/local-bus'>MTA Buses</a> &mdash; there are many in the area, but these are the closest (within one block of the venue):
     <ul>
       <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+3'>Route 3</a> (Northbound)
       <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+11'>Route 11</a> (Northbound and Southbound)

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -108,7 +108,14 @@ $12 Daily Max</p>
 
 <h2>Access via Public Transportation:</h2>
 <ul>
-  <li>MTA Bus system: The University is located on major metropolitan bus routes.
+  <li>MTA Buses &mdash; there are many in the area, but these are the closest (within one block of the venue):
+    <ul>
+      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+3'>Route 3</a> (Northbound)
+      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+11'>Route 11</a> (Northbound and Southbound)
+      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+21'>Route 21</a> (Northbound and Southbound)
+      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+61'>Route 61</a> (Northbound)
+      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+64'>Route 64</a> (Northbound)
+    </ul>
   <li>Subway: The Maryland State Office Building Metro Station is 4 blocks from the University.
   <li>Light Rail: The University of Baltimore/Mount Royal Station is located adjacent to the Fitzgerald Garage ( Mt Royal &amp; Oliver)
   <li>By Intercity Train: The University is one block south of Pennsylvania Station (Amtrak/MARC) on North Charles Street.

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -81,21 +81,15 @@
 The Thumel Business Center of the University of Baltimore is very close to Penn Station, easily walkable. It is located near food and other attractions in the heart of Baltimore, MD.
 </p>
 
-Thumel Business Center<br>
-University of Baltimore<br>
-11 W Mount Royal Ave Baltimore, MD, 21201<br>
+<p>11 W Mount Royal Ave Baltimore, MD, 21201 (<a href='https://maps.google.com/maps?q=11+W+Mount+Royal+Ave+Baltimore%2C+MD%2C+21201'>Google Maps</a>, <a href='http://maps.apple.com/?q=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps</a>)</p>
 
 <p>
-<iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://maps.google.com/maps?q=11+W+Mount+Royal+Ave+Baltimore,+MD,+21201&amp;ie=UTF8&amp;hq=&amp;hnear=11+W+Mt+Royal+Ave,+Baltimore,+Maryland+21201&amp;t=m&amp;z=14&amp;ll=39.305358,-76.616728&amp;output=embed"></iframe><br /><small><a href="https://maps.google.com/maps?q=11+W+Mount+Royal+Ave+Baltimore,+MD,+21201&amp;ie=UTF8&amp;hq=&amp;hnear=11+W+Mt+Royal+Ave,+Baltimore,+Maryland+21201&amp;t=m&amp;z=14&amp;ll=39.305358,-76.616728&amp;source=embed" style="color:#0000FF;text-align:left">View Larger Map</a></small>
-</p>
-
-<p>
-The University of Baltimore is located at 1420 North Charles St. at Mount Royal Avenue.  The Law Center and Student Center are located at Maryland and Mount Royal Avenues.  The Business Center is located at N. Charles St. and West Mount Royal Avenue.  Langsdale Library Auditorium is located at Oliver St. and Maryland Avenue.  The Academic Center is located on N. Charles St. prior to the Jones Falls Expressway exit.
+<iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://maps.google.com/maps?q=11+W+Mount+Royal+Ave+Baltimore,+MD,+21201&amp;ie=UTF8&amp;hq=&amp;hnear=11+W+Mt+Royal+Ave,+Baltimore,+Maryland+21201&amp;t=m&amp;z=14&amp;ll=39.305358,-76.616728&amp;output=embed"></iframe>
 </p>
 
 <h2>Driving Directions / Parking:</h2>
 
-<p>(This is mostly copied from the <a href="http://law.ubalt.edu/about/directions.cfm">U of B directions page</a>.)</p>
+<p>For more detailed directions, please consult the <a href="http://law.ubalt.edu/about/directions.cfm">University of Baltimore's website</a>.</p>
 
 <p>
   <a href='http://www.fitzparking.com/'>The Fitzgerald Garage</a> located on the corner of Oliver St. and Mt. Royal Avenue:

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -75,7 +75,7 @@
 
 
       <div id="content">  <!-- Test -->
-        <h2>Venue - Thumel Business Center, University of Baltimore</h2>,
+        <h2>Venue - Thumel Business Center, University of Baltimore</h2>
 
 <p>
 The Thumel Business Center of the University of Baltimore is very close to Penn Station, easily walkable. It is located near food and other attractions in the heart of Baltimore, MD.
@@ -93,14 +93,19 @@ University of Baltimore<br>
 The University of Baltimore is located at 1420 North Charles St. at Mount Royal Avenue.  The Law Center and Student Center are located at Maryland and Mount Royal Avenues.  The Business Center is located at N. Charles St. and West Mount Royal Avenue.  Langsdale Library Auditorium is located at Oliver St. and Maryland Avenue.  The Academic Center is located on N. Charles St. prior to the Jones Falls Expressway exit.
 </p>
 
-<h2>Directions / Parking</h2>
+<h2>Driving Directions / Parking:</h2>
 
 <p>(This is mostly copied from the <a href="http://law.ubalt.edu/about/directions.cfm">U of B directions page</a>.)</p>
 
-<p>The Fitzgerald Garage located on the corner of Oliver St. and Mt. Royal Avenue. $6 for up to 2 hours;<br>
-$9 for up to 3 hours;<br>
-$11 for up to 4 hours;<br>
-$12 Daily Max</p>
+<p>
+  <a href='http://www.fitzparking.com/'>The Fitzgerald Garage</a> located on the corner of Oliver St. and Mt. Royal Avenue:
+  <ul>
+    <li>$6 for up to 2 hours
+    <li>$9 for up to 3 hours
+    <li>$11 for up to 4 hours
+    <li>$12 Daily Max
+  </ul>
+</p>
 
 <p>From Baltimore Beltway (I-695): Take Route 695 to exit 23, Jones Falls Expressway (I-83).  Exit I-83 at the Maryland Avenue exit.  From the exit ramp cross Maryland Avenue onto Oliver St. Make a right into the Fitzgerald Garage.</p>
 <p>From Washington D.C.: Take I-495 North to I-95 North follow signs to downtown Baltimore.  Make a right onto Pratt St. and then a left onto N. Charles St. Follow N. Charles St. and make a left onto Mt. Royal Avenue.  Follow Mt. Royal Avenue, across Maryland Avenue, past the Lyric Theater, and make a right onto Oliver St.  Make an immediate left in to the Fitzgerald Garage.</p>
@@ -108,7 +113,7 @@ $12 Daily Max</p>
 
 <h2>Access via Public Transportation:</h2>
 <ul>
-  <li><a href='http://mta.maryland.gov/local-bus'>MTA Buses</a> &mdash; there are many in the area, but these are the closest (within one block of the venue):
+  <li><a href='http://mta.maryland.gov/local-bus'>MTA Buses</a>: there are many in the area, but five routes have stops within one block of the Thumel Business Center.
     <ul>
       <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+3'>Route 3</a> (Northbound)
       <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+11'>Route 11</a> (Northbound and Southbound)
@@ -118,8 +123,8 @@ $12 Daily Max</p>
     </ul>
   <li><a href='http://mta.maryland.gov/metro-subway'>Subway</a>: The Maryland State Office Building Metro Station is 4 blocks from the University.
     <ul>
-      <li><a href='https://goo.gl/maps/pLFKJyT9YKm'>Google Maps Directions</a>
-      <li><a href='http://maps.apple.com/?saddr=201+West+Preston+Street%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps Directions</a>
+      <li><a href='https://goo.gl/maps/pLFKJyT9YKm'>Google Maps</a> Directions
+      <li><a href='http://maps.apple.com/?saddr=201+West+Preston+Street%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps</a> Directions
     </ul>
   <li>Light Rail: The University of Baltimore/Mount Royal Station is located adjacent to the Fitzgerald Garage ( Mt Royal &amp; Oliver)
   <li>By Intercity Train: The University is one block south of Pennsylvania Station (Amtrak/MARC) on North Charles Street.

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -113,6 +113,15 @@ The Thumel Business Center of the University of Baltimore is very close to Penn 
 <p>For more detailed directions, please consult the <a href="http://law.ubalt.edu/about/directions.cfm">University of Baltimore's website</a>.</p>
 
 <h2>Access via Public Transportation:</h2>
+
+<p>
+  <b>Note to DC attendees</b>: The WMATA's
+  <a href='http://www.wmata.com/fares/smartrip/'>SmartTrip</a>&reg;
+  is fully cross-compatible with Baltimore's
+  <a href='http://www.mtacharmcard.com/'>CharmCard</a>&reg;, and can be used
+  to pay for for MTA, Light Rail, and Subway travel.
+</p>
+
 <ul>
   <li><a href='http://mta.maryland.gov/local-bus'>MTA Buses</a>: there are many in the area, but five routes have stops within one block of the Thumel Business Center.
     <ul>

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -118,7 +118,6 @@ $12 Daily Max</p>
     </ul>
   <li><a href='http://mta.maryland.gov/metro-subway'>Subway</a>: The Maryland State Office Building Metro Station is 4 blocks from the University.
     <ul>
-      <li><b>Note</b> that the Light Rail (more info below) offers a convenient transfer option as well!
       <li><a href='https://goo.gl/maps/pLFKJyT9YKm'>Google Maps Directions</a>
       <li><a href='http://maps.apple.com/?saddr=201+West+Preston+Street%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps Directions</a>
     </ul>

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -107,10 +107,12 @@ $12 Daily Max</p>
 <p>From Phil./N.Y.: Take I -95 South to I-695 West follow signs to Baltimore.  Exit I-695 at the Jones Falls Expressway; exit 23(I-83).  Exit I-83 at the Maryland Avenue exit.   Go straight on to Oliver Street and make an immediate right into the Fitzgerald Garage.</p>
 
 <h2>Access via Public Transportation:</h2>
-<p>MTA Bus system: The University is located on major metropolitan bus routes.</p>
-<p>Subway: The Maryland State Office Building Metro Station is 4 blocks from the University.</p>
-<p>Light Rail: The University of Baltimore/Mount Royal Station is located adjacent to the Fitzgerald Garage ( Mt Royal &amp; Oliver)</p>
-<p>By Intercity Train: The University is one block south of Pennsylvania Station (Amtrak/MARC) on North Charles Street.</p>
+<ul>
+  <li>MTA Bus system: The University is located on major metropolitan bus routes.
+  <li>Subway: The Maryland State Office Building Metro Station is 4 blocks from the University.
+  <li>Light Rail: The University of Baltimore/Mount Royal Station is located adjacent to the Fitzgerald Garage ( Mt Royal &amp; Oliver)
+  <li>By Intercity Train: The University is one block south of Pennsylvania Station (Amtrak/MARC) on North Charles Street.
+</ul>
 
 <p>&nbsp;</p>
       

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -116,7 +116,12 @@ $12 Daily Max</p>
       <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+61'>Route 61</a> (Northbound)
       <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+64'>Route 64</a> (Northbound)
     </ul>
-  <li>Subway: The Maryland State Office Building Metro Station is 4 blocks from the University.
+  <li><a href='http://mta.maryland.gov/metro-subway'>Subway</a>: The Maryland State Office Building Metro Station is 4 blocks from the University.
+    <ul>
+      <li><b>Note</b> that the Light Rail (more info below) offers a convenient transfer option as well!
+      <li><a href='https://goo.gl/maps/pLFKJyT9YKm'>Google Maps Directions</a>
+      <li><a href='http://maps.apple.com/?saddr=201+West+Preston+Street%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps Directions</a>
+    </ul>
   <li>Light Rail: The University of Baltimore/Mount Royal Station is located adjacent to the Fitzgerald Garage ( Mt Royal &amp; Oliver)
   <li>By Intercity Train: The University is one block south of Pennsylvania Station (Amtrak/MARC) on North Charles Street.
 </ul>

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -116,7 +116,7 @@ The Thumel Business Center of the University of Baltimore is very close to Penn 
 
 <p>
   <b>Note to DC attendees</b>: The WMATA's
-  <a href='http://www.wmata.com/fares/smartrip/'>SmartTrip</a>&reg;
+  <a href='http://www.wmata.com/fares/smartrip/'>SmarTrip</a>&reg;
   is fully cross-compatible with Baltimore's
   <a href='http://www.mtacharmcard.com/'>CharmCard</a>&reg;, and can be used
   to pay for for MTA, Light Rail, and Subway travel.

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -89,10 +89,15 @@ The Thumel Business Center of the University of Baltimore is very close to Penn 
 
 <h2>Driving Directions / Parking:</h2>
 
-<p>For more detailed directions, please consult the <a href="http://law.ubalt.edu/about/directions.cfm">University of Baltimore's website</a>.</p>
-
 <p>
-  <a href='http://www.fitzparking.com/'>The Fitzgerald Garage</a> located on the corner of Oliver St. and Mt. Royal Avenue:
+  Street parking is available near the venue, but as this is a busy section of
+  the city, is not guaranteed. For this reason, and per the University of
+  Baltimore's recommendation, we suggest the
+  <a href='http://www.fitzparking.com/'>Fitzgerald Garage</a>,
+  located on the corner of Oliver St. and Mt. Royal Avenue
+  (<a href='https://maps.google.com/maps?q=1201+W+Mount+Royal+Ave+Baltimore,+MD,+21201'>Google Maps</a>,
+  <a href='http://maps.apple.com/?daddr=1201+W+Mount+Royal+Ave+Baltimore%2C+MD%2C+21201&dirflg=d'>Apple Maps</a>),
+  which has the following rates:
   <ul>
     <li>$6 for up to 2 hours
     <li>$9 for up to 3 hours
@@ -104,6 +109,8 @@ The Thumel Business Center of the University of Baltimore is very close to Penn 
 <p>From Baltimore Beltway (I-695): Take Route 695 to exit 23, Jones Falls Expressway (I-83).  Exit I-83 at the Maryland Avenue exit.  From the exit ramp cross Maryland Avenue onto Oliver St. Make a right into the Fitzgerald Garage.</p>
 <p>From Washington D.C.: Take I-495 North to I-95 North follow signs to downtown Baltimore.  Make a right onto Pratt St. and then a left onto N. Charles St. Follow N. Charles St. and make a left onto Mt. Royal Avenue.  Follow Mt. Royal Avenue, across Maryland Avenue, past the Lyric Theater, and make a right onto Oliver St.  Make an immediate left in to the Fitzgerald Garage.</p>
 <p>From Phil./N.Y.: Take I -95 South to I-695 West follow signs to Baltimore.  Exit I-695 at the Jones Falls Expressway; exit 23(I-83).  Exit I-83 at the Maryland Avenue exit.   Go straight on to Oliver Street and make an immediate right into the Fitzgerald Garage.</p>
+
+<p>For more detailed directions, please consult the <a href="http://law.ubalt.edu/about/directions.cfm">University of Baltimore's website</a>.</p>
 
 <h2>Access via Public Transportation:</h2>
 <ul>

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -96,7 +96,7 @@ The Thumel Business Center of the University of Baltimore is very close to Penn 
   <a href='http://www.fitzparking.com/'>Fitzgerald Garage</a>,
   located on the corner of Oliver St. and Mt. Royal Avenue
   (<a href='https://maps.google.com/maps?q=1201+W+Mount+Royal+Ave+Baltimore,+MD,+21201'>Google Maps</a>,
-  <a href='http://maps.apple.com/?daddr=1201+W+Mount+Royal+Ave+Baltimore%2C+MD%2C+21201&dirflg=d'>Apple Maps</a>),
+  <a href='http://maps.apple.com/?daddr=1201+W+Mount+Royal+Ave+Baltimore%2C+MD%2C+21201&amp;dirflg=d'>Apple Maps</a>),
   which has the following rates:
   <ul>
     <li>$6 for up to 2 hours
@@ -125,30 +125,30 @@ The Thumel Business Center of the University of Baltimore is very close to Penn 
 <ul>
   <li><a href='http://mta.maryland.gov/local-bus'>MTA Buses</a>: there are many in the area, but five routes have stops within one block of the Thumel Business Center.
     <ul>
-      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+3'>Route 3</a> (Northbound)
-      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+11'>Route 11</a> (Northbound and Southbound)
-      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+21'>Route 21</a> (Northbound and Southbound)
-      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+61'>Route 61</a> (Northbound)
-      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&route=Route+64'>Route 64</a> (Northbound)
+      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&amp;route=Route+3'>Route 3</a> (Northbound)
+      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&amp;route=Route+11'>Route 11</a> (Northbound and Southbound)
+      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&amp;route=Route+21'>Route 21</a> (Northbound and Southbound)
+      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&amp;route=Route+61'>Route 61</a> (Northbound)
+      <li><a href='http://mta.maryland.gov/share-bus-overview?bus_service=Local+Bus&amp;route=Route+64'>Route 64</a> (Northbound)
     </ul>
   <li><a href='http://mta.maryland.gov/metro-subway'>Subway</a>: The Maryland State Office Building Metro Station is 4 blocks from the University.
     <ul>
       <li><a href='https://goo.gl/maps/pLFKJyT9YKm'>Google Maps</a> Directions
-      <li><a href='http://maps.apple.com/?saddr=201+West+Preston+Street%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps</a> Directions
+      <li><a href='http://maps.apple.com/?saddr=201+West+Preston+Street%2C+Baltimore%2C+MD+21201&amp;daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps</a> Directions
     </ul>
   <li><a href='http://mta.maryland.gov/light-rail'>Light Rail</a>: The University of Baltimore/Mount Royal Station, with service from <a href='http://www.bwiairport.com/en'>BWI Airport</a>, is located adjacent to the <a href='http://www.fitzparking.com/'>Fitzgerald Garage</a>.
     <ul>
       <li><a href='https://goo.gl/maps/CxGWBPzm8YA2'>Google Maps</a> Directions
-      <li><a href='http://maps.apple.com/?saddr=1200+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps</a> Directions
+      <li><a href='http://maps.apple.com/?saddr=1200+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201&amp;daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps</a> Directions
     </ul>
   <li><a href='http://www.charmcitycirculator.com/'>Charm City Circulator</a>: The <a href='http://www.charmcitycirculator.com/route/purple'>Purple Route</a> of Baltimore's free bus service has two stops within blocks of the University.
     <ul>
-      <li><a href='http://www.nextbus.com/customStopSelector/fancyNewPredictionLayer.jsp?a=charm-city&r=purple&d=baltvc&s=pennsta_f&ts=charnort&cssFile=http://charmcitycirculator.com/sites/all/themes/ccc/nextbus-gmap.css#'>310 - Penn Station Northbound</a> (<a href='http://maps.apple.com/?saddr=1545+W+N.+Charles+St.%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201&dirflg=w'>Apple Maps</a> Directions, <a href='https://goo.gl/maps/4Nw2NqNYgXF2'>Google Maps</a> Directions)
-      <li><a href='http://www.nextbus.com/customStopSelector/fancyNewPredictionLayer.jsp?a=charm-city&r=purple&d=baltvc&s=pennsta311_f&ts=pres_f&cssFile=http://charmcitycirculator.com/sites/all/themes/ccc/nextbus-gmap.css#'>321 - Penn Station Southbound</a> (<a href='http://maps.apple.com/?saddr=1600+W+St.+Paul+St.%2C+Baltimore%2C+MD+21201&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201&dirflg=w'>Apple Maps</a> Directions, <a href='https://goo.gl/maps/ihTfPAGLDy32'>Google Maps</a> Directions)
+      <li><a href='http://www.nextbus.com/customStopSelector/fancyNewPredictionLayer.jsp?a=charm-city&amp;r=purple&amp;d=baltvc&amp;s=pennsta_f&amp;ts=charnort&amp;cssFile=http://charmcitycirculator.com/sites/all/themes/ccc/nextbus-gmap.css#'>310 - Penn Station Northbound</a> (<a href='http://maps.apple.com/?saddr=1545+W+N.+Charles+St.%2C+Baltimore%2C+MD+21201&amp;daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201&amp;dirflg=w'>Apple Maps</a> Directions, <a href='https://goo.gl/maps/4Nw2NqNYgXF2'>Google Maps</a> Directions)
+      <li><a href='http://www.nextbus.com/customStopSelector/fancyNewPredictionLayer.jsp?a=charm-city&amp;r=purple&amp;d=baltvc&amp;s=pennsta311_f&amp;ts=pres_f&amp;cssFile=http://charmcitycirculator.com/sites/all/themes/ccc/nextbus-gmap.css#'>321 - Penn Station Southbound</a> (<a href='http://maps.apple.com/?saddr=1600+W+St.+Paul+St.%2C+Baltimore%2C+MD+21201&amp;daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201&amp;dirflg=w'>Apple Maps</a> Directions, <a href='https://goo.gl/maps/ihTfPAGLDy32'>Google Maps</a> Directions)
     </ul>
   <li>Intercity Train: Baltimore's Penn Station is just around the corner from the Thumel Business Center.
     <ul>
-      <li><a href='http://www.amtrak.com/servlet/ContentServer?pagename=am/am2Station/Station_Page&code=BAL'>Amtrak</a> has lines going through Baltimore from many US Cities.
+      <li><a href='http://www.amtrak.com/servlet/ContentServer?pagename=am/am2Station/Station_Page&amp;code=BAL'>Amtrak</a> has lines going through Baltimore from many US Cities.
       <li><a href='http://mta.maryland.gov/marc-train'>MARC</a> trains provide an affordable commuter route between DC and Baltimore.
     </ul>
 </ul>

--- a/dcbpw2016/venue/index.html
+++ b/dcbpw2016/venue/index.html
@@ -131,7 +131,11 @@ The University of Baltimore is located at 1420 North Charles St. at Mount Royal 
       <li><a href='https://goo.gl/maps/CxGWBPzm8YA2'>Google Maps</a> Directions
       <li><a href='http://maps.apple.com/?saddr=&daddr=11+W+Mt.+Royal+Ave.%2C+Baltimore%2C+MD+21201'>Apple Maps</a> Directions
     </ul>
-  <li>By Intercity Train: The University is one block south of Pennsylvania Station (Amtrak/MARC) on North Charles Street.
+  <li>By Intercity Train: Baltimore's Penn Station is just around the corner from the Thumel Business Center.
+    <ul>
+      <li><a href='http://www.amtrak.com/servlet/ContentServer?pagename=am/am2Station/Station_Page&code=BAL'>Amtrak</a> has lines going through Baltimore from many US Cities.
+      <li><a href='http://mta.maryland.gov/marc-train'>MARC</a> trains provide an affordable commuter route between DC and Baltimore.
+    </ul>
 </ul>
 
 <p>&nbsp;</p>


### PR DESCRIPTION
Though I don't feel like there should be any objections to this, it's a
fairly sizable change in the information presented on the "Venue" page,
regarding the various navigation options. That is, a lot of the
information that was originally provided to us as a generic "Welcome to
the University of Baltimore" has been stripped out. And, a significant
number of links to the various modes of transportation and Google/Apple
maps have been added.

If any objection can be made to my changes, I certainly expect it to
come from the realm of "now the page is over-saturated with links",
which I could believe; after all, they're mostly all just pointing to
ways to get to the Business Center. Still, I do feel some attendees
might appreciate being able to see immediately which ways are the
closest/fastest ways to get to the venue for them.

However, the real reason I *originally* did this as a pull request and
not as a direct push into `origin/master`, is that I originally fully
intended to link people to an app that uses public GPS data to track
locations of various public transit vehicles, making navigating the city
easier.

I've by-and-large talked myself out of it for the time being, as the app
is published by a private company, and I feel it might be improper for
us to appear to be endorsing a private company with which we have no
current relationship, just because I personally like the app. But, I'm
eager to see if anyone else has any thoughts on the matter. If so, I
could probably fairly easily be convinced to add the links.

Otherwise, I'm just happy to have someone do a quick proof-read on my
edits and merge them in.